### PR TITLE
Adding the path prefix option

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Usage: twproxy [options]
     -b, --bind HOSTNAME              Specify hostname to bind to. Defaults to 127.0.0.1.
     -s, --enable-ssl                 Ensures cookies are marked as secure.
     -d, --destination URL            Specify the url of the TiddlyWiki server. Defaults to http://localhost:8080.
+    -x, --path-prefix PATH_PREFIX    Specify the path prefix of the TiddlyWiki server (according to [path-prefix](http://tiddlywiki.com/#Using%20a%20custom%20path%20prefix%20with%20the%20client-server%20edition). Defaults to "/".
     -g CLEARTEXT,                    Generates a SHA1 hashed password
         --generate-password
     -u, --username USER              Sets the username. Defaults to user.

--- a/bin/twproxy
+++ b/bin/twproxy
@@ -20,6 +20,9 @@ OptionParser.new do |opts|
   opts.on("-d", "--destination URL", "Specify the url of the TiddlyWiki server. Defaults to http://localhost:8080.") do |url|
     options[:url] = url
   end
+  opts.on("-x", "--path-prefix PATH_PREFIX", "Specify the path prefix of the TiddlyWiki server, if existing. Defaults to /.") do |path_prefix|
+    options[:path_prefix] = path_prefix
+  end
   opts.on("-g", "--generate-password CLEARTEXT", "Generates a SHA1 hashed password") do |pass|
     puts Digest::SHA1.hexdigest(pass)
     exit
@@ -44,11 +47,11 @@ TWProxy.set :bind, options[:bind] || "127.0.0.1"
 TWProxy.set :port, options[:port] || 8888
 TWProxy.set :enable_ssl, options[:enable_ssl] || false
 TWProxy.set :url, options[:url] || "http://localhost:8080" || ENV['WIKI_URL']
+TWProxy.set :path_prefix, options[:path_prefix] || "/"
 TWProxy.set :username, options[:username] || ENV['WIKI_USER'] || "user"
 # Default password is test
-TWProxy.set :password, 
-  options[:password] || ENV['WIKI_PASS'] || "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3"
+TWProxy.set :password,
+            options[:password] || ENV['WIKI_PASS'] || "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3"
 TWProxy.set :auth, options[:auth] || ENV['WIKI_AUTH']
 
 TWProxy.run!
-

--- a/lib/twproxy/proxy.rb
+++ b/lib/twproxy/proxy.rb
@@ -54,7 +54,7 @@ class TWProxy < Sinatra::Base
                                   expires: (Date.today >> 1).to_time,
                                   httponly: true)
 
-      redirect "/"
+      redirect "#{settings.path_prefix}"
     else
       @error = "Invalid username/password"
       haml :login


### PR DESCRIPTION
I think I found a very simple solution for: #1 
Added the option to parse a path prefix like in tiddlywiki as well. updated the readme accordingly. Tested with a local installation in my VM. Maybe you should test it as well, before you accept the PR.