### PR TITLE
Add `x-requested-with` header to unbreak recent version of TW

### DIFF
--- a/lib/twproxy/proxy.rb
+++ b/lib/twproxy/proxy.rb
@@ -83,7 +83,8 @@ class TWProxy < Sinatra::Base
     uri = get_uri
     http = Net::HTTP.new(uri.host, uri.port)
 
-    req = Net::HTTP::Put.new(uri.request_uri, initheader = { "Content-Type" => "application/json"})
+    req = Net::HTTP::Put.new(uri.request_uri, initheader = { "Content-Type" => "application/json", "x-requested-with" => "TiddlyWiki"})
+
     request.body.rewind
     req.body = request.body.read
 
@@ -98,7 +99,7 @@ class TWProxy < Sinatra::Base
     uri = get_uri
     http = Net::HTTP.new(uri.host, uri.port)
 
-    req = Net::HTTP::Delete.new(uri.request_uri)
+    req = Net::HTTP::Delete.new(uri.request_uri, initheader = { "x-requested-with" => "TiddlyWiki"})
     resp = http.request(req)
 
     status resp.code


### PR DESCRIPTION
I updated various components on my server, related to tiddlywiki (plugins, TW itself, this wonderful gem, etc.), and it broke, with the exact symptoms explained in #6.

I tracked this down to a CSRF check in TW, using `http.set_debug_output($stdout)`, the HTTP response from downstream (the TW server) was:

```
-> "HTTP/1.1 403 'X-Requested-With' header required to login to 'My ~TiddlyWiki'\r\n"
```

Adding this header repairs the whole thing. I'd have wished for a way to get all the upstream HTTP headers, but it doesn't appear to exist (neither in Sinatra nor in Rack, that mangles the headers and put them in `env` with an `HTTP_` prefix and some upper casing etc., however I'm by no mean a ruby person, so I'm happy to be proven wrong). Iterating over the headers, checking that they start with `HTTP_` and adding that to the downstream request header would be nicer, but it's unnecessary and ugly.

A similar fix has been done for the `delete` case for the same reason.

I suppose that an alternative fix would be to disable CSRF checks in TW, as https://tiddlywiki.com/static/WebServer%2520Parameter%253A%2520csrf-disable.html seem to indicate, but conceptually, a proxy should probably pass things through untouched.